### PR TITLE
Fix batch writer when batching disabled

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -30,10 +30,11 @@ func (tun *tunnelCon) write(buf []byte) {
 }
 
 func (tun *tunnelCon) batchWriter() {
-	if batchingMicroseconds == 0 {
-		return
+	interval := time.Second
+	if batchingMicroseconds > 0 {
+		interval = time.Microsecond * time.Duration(batchingMicroseconds)
 	}
-	ticker := time.NewTicker(time.Microsecond * time.Duration(batchingMicroseconds))
+	ticker := time.NewTicker(interval)
 
 	if debugLog {
 		defer doLog("batchWriter: exit")


### PR DESCRIPTION
## Summary
- ensure `batchWriter` keeps running even when `batchingMicroseconds` is zero

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68466f9ed724832ab36af69c11176f65