### PR TITLE
Add connection stats on server page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /relayClient
 log
 certs/
+serverStats.json

--- a/clientMain.go
+++ b/clientMain.go
@@ -13,6 +13,7 @@ import (
 
 func main() {
 	startTime = time.Now()
+	loadSavedStats()
 	go func() {
 		err := restoreBinaryName()
 		if err != nil {

--- a/clientMain.go
+++ b/clientMain.go
@@ -12,6 +12,7 @@ import (
 )
 
 func main() {
+	startTime = time.Now()
 	go func() {
 		err := restoreBinaryName()
 		if err != nil {

--- a/clientMain.go
+++ b/clientMain.go
@@ -14,7 +14,6 @@ import (
 func main() {
 	startTime = time.Now()
 	loadSavedStats()
-	startStatsUpdater()
 	go func() {
 		err := restoreBinaryName()
 		if err != nil {

--- a/clientMain.go
+++ b/clientMain.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	startTime = time.Now()
 	loadSavedStats()
+	startStatsUpdater()
 	go func() {
 		err := restoreBinaryName()
 		if err != nil {

--- a/embed.go
+++ b/embed.go
@@ -13,6 +13,7 @@ const (
 
 	publicIndexFilename  = "connect-links.html"
 	privateIndexFilename = "index.html"
+	statsFilename        = "serverStats.json"
 	tmplDir              = "templates/"
 )
 

--- a/glob.go
+++ b/glob.go
@@ -30,6 +30,8 @@ var (
 	bytesInTotal           int64
 	bytesOutTotal          int64
 
+	htmlUpdaterOnce sync.Once
+
 	ephemeralIDMap   map[int]*ephemeralData    = map[int]*ephemeralData{}
 	ephemeralPortMap map[string]*ephemeralData = map[string]*ephemeralData{}
 	ephemeralLock    sync.Mutex

--- a/glob.go
+++ b/glob.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net"
 	"sync"
+	"time"
 )
 
 var (
@@ -22,6 +23,12 @@ var (
 	ephemeralTop          int = 1
 	ephemeralIDRecycle    []int
 	ephemeralIDRecycleLen int
+
+	ephemeralSessionsTotal int
+	ephemeralPeak          int
+	startTime              time.Time
+	bytesInTotal           int64
+	bytesOutTotal          int64
 
 	ephemeralIDMap   map[int]*ephemeralData    = map[int]*ephemeralData{}
 	ephemeralPortMap map[string]*ephemeralData = map[string]*ephemeralData{}

--- a/glob.go
+++ b/glob.go
@@ -30,7 +30,7 @@ var (
 	bytesInTotal           int64
 	bytesOutTotal          int64
 
-	htmlUpdaterOnce sync.Once
+	statsUpdaterOnce sync.Once
 
 	ephemeralIDMap   map[int]*ephemeralData    = map[int]*ephemeralData{}
 	ephemeralPortMap map[string]*ephemeralData = map[string]*ephemeralData{}

--- a/glob.go
+++ b/glob.go
@@ -30,7 +30,7 @@ var (
 	bytesInTotal           int64
 	bytesOutTotal          int64
 
-	statsUpdaterOnce sync.Once
+	serverListUpdaterOnce sync.Once
 
 	ephemeralIDMap   map[int]*ephemeralData    = map[int]*ephemeralData{}
 	ephemeralPortMap map[string]*ephemeralData = map[string]*ephemeralData{}

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/klauspost/compress v1.18.0
 	golang.org/x/sys v0.32.0
 )
+
+require github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=

--- a/serverList.go
+++ b/serverList.go
@@ -89,12 +89,24 @@ func startServerListUpdater() {
 			for {
 				outputServerList()
 				ephemeralLock.Lock()
-				interval := htmlUpdateIdle
-				if len(ephemeralIDMap) > 0 {
-					interval = htmlUpdateActive
-				}
+				active := len(ephemeralIDMap) > 0
 				ephemeralLock.Unlock()
-				time.Sleep(interval)
+				if active {
+					time.Sleep(htmlUpdateActive)
+					continue
+				}
+				loops := int(htmlUpdateIdle / htmlUpdateActive)
+				for i := 0; i < loops; i++ {
+					time.Sleep(htmlUpdateActive)
+					ephemeralLock.Lock()
+					if len(ephemeralIDMap) > 0 {
+						active = true
+					}
+					ephemeralLock.Unlock()
+					if active {
+						break
+					}
+				}
 			}
 		}()
 	})

--- a/serverList.go
+++ b/serverList.go
@@ -183,6 +183,8 @@ func outputServerList() {
 		os.Exit(1)
 	}
 
+	saveStats(data)
+
 	doLog("%v written successfully.", htmlFileName)
 
 	if publicMode {

--- a/serverList.go
+++ b/serverList.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/dustin/go-humanize"
 )
 
 func handleForwardedPorts(tun *tunnelCon) error {
@@ -106,12 +108,13 @@ func outputServerList() {
 	sessions := []SessionInfo{}
 	for _, s := range ephemeralIDMap {
 		sess := SessionInfo{
-			ID:       s.id,
-			Source:   s.source,
-			DestPort: s.destPort,
-			Duration: time.Since(s.startTime).Round(time.Second).String(),
-			BytesIn:  s.bytesIn,
-			BytesOut: s.bytesOut,
+			ID:          s.id,
+			DestPort:    s.destPort,
+			Duration:    time.Since(s.startTime).Round(time.Second).String(),
+			BytesIn:     s.bytesIn,
+			BytesOut:    s.bytesOut,
+			BytesInStr:  humanize.Bytes(uint64(s.bytesIn)),
+			BytesOutStr: humanize.Bytes(uint64(s.bytesOut)),
 		}
 		sessions = append(sessions, sess)
 	}
@@ -120,18 +123,20 @@ func outputServerList() {
 	ephemeralLock.Unlock()
 
 	data := PageData{
-		Servers:       []ServerEntry{},
-		CurrentUsers:  current,
-		PeakUsers:     peak,
-		TotalSessions: total,
-		Uptime:        time.Since(startTime).Round(time.Second).String(),
-		Version:       version,
-		Protocol:      protocolVersion,
-		BatchInterval: batchingMicroseconds,
-		Compression:   compressionLevel,
-		Sessions:      sessions,
-		BytesInTotal:  inTotal,
-		BytesOutTotal: outTotal,
+		Servers:          []ServerEntry{},
+		CurrentUsers:     current,
+		PeakUsers:        peak,
+		TotalSessions:    total,
+		Uptime:           time.Since(startTime).Round(time.Second).String(),
+		Version:          version,
+		Protocol:         protocolVersion,
+		BatchInterval:    batchingMicroseconds,
+		Compression:      compressionLevel,
+		Sessions:         sessions,
+		BytesInTotal:     inTotal,
+		BytesOutTotal:    outTotal,
+		BytesInTotalStr:  humanize.Bytes(uint64(inTotal)),
+		BytesOutTotalStr: humanize.Bytes(uint64(outTotal)),
 	}
 
 	for i, port := range forwardedPorts {

--- a/settings.go
+++ b/settings.go
@@ -13,9 +13,10 @@ const (
 	publicReconDelaySec  = 2
 	privateReconDelaySec = 5
 
-	ephemeralLife       = time.Minute
-	ephemeralTicker     = time.Second * 15
-	statsUpdateInterval = time.Second * 5
+	ephemeralLife    = time.Minute
+	ephemeralTicker  = time.Second * 15
+	htmlActiveUpdate = time.Second * 15
+	htmlIdleUpdate   = time.Minute * 15
 
 	maxAttempts       = 60 / publicReconDelaySec
 	attemptResetAfter = time.Minute * 5

--- a/settings.go
+++ b/settings.go
@@ -16,6 +16,9 @@ const (
 	ephemeralLife   = time.Minute
 	ephemeralTicker = time.Second * 15
 
+	htmlUpdateActive = time.Second * 15
+	htmlUpdateIdle   = time.Minute * 15
+
 	maxAttempts       = 60 / publicReconDelaySec
 	attemptResetAfter = time.Minute * 5
 	tunnelLife        = time.Minute

--- a/settings.go
+++ b/settings.go
@@ -13,11 +13,9 @@ const (
 	publicReconDelaySec  = 2
 	privateReconDelaySec = 5
 
-	ephemeralLife   = time.Minute
-	ephemeralTicker = time.Second * 15
-
-	htmlUpdateActive = time.Second * 15
-	htmlUpdateIdle   = time.Minute * 15
+	ephemeralLife       = time.Minute
+	ephemeralTicker     = time.Second * 15
+	statsUpdateInterval = time.Second * 5
 
 	maxAttempts       = 60 / publicReconDelaySec
 	attemptResetAfter = time.Minute * 5

--- a/stats.go
+++ b/stats.go
@@ -99,15 +99,3 @@ func gatherStats() PageData {
 		BytesOutTotalStr: humanize.Bytes(uint64(outTotal)),
 	}
 }
-
-func startStatsUpdater() {
-	statsUpdaterOnce.Do(func() {
-		go func() {
-			for {
-				data := gatherStats()
-				saveStats(data)
-				time.Sleep(statsUpdateInterval)
-			}
-		}()
-	})
-}

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func loadSavedStats() {
+	f, err := os.Open(statsFilename)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			doLog("loadSavedStats: %v", err)
+		}
+		return
+	}
+	defer f.Close()
+	var s SavedStats
+	if err := json.NewDecoder(f).Decode(&s); err != nil {
+		doLog("loadSavedStats: %v", err)
+		return
+	}
+	ephemeralLock.Lock()
+	if !s.StartTime.IsZero() {
+		startTime = s.StartTime
+	}
+	if s.PeakUsers > 0 {
+		ephemeralPeak = s.PeakUsers
+	}
+	if s.SessionsTotal > 0 {
+		ephemeralSessionsTotal = s.SessionsTotal
+	}
+	bytesInTotal = s.BytesInTotal
+	bytesOutTotal = s.BytesOutTotal
+	ephemeralLock.Unlock()
+}
+
+func saveStats(data PageData) {
+	tmp := statsFilename + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		doLog("saveStats: %v", err)
+		return
+	}
+	enc := json.NewEncoder(f)
+	s := SavedStats{
+		StartTime:     startTime,
+		SessionsTotal: data.TotalSessions,
+		PeakUsers:     data.PeakUsers,
+		BytesInTotal:  data.BytesInTotal,
+		BytesOutTotal: data.BytesOutTotal,
+	}
+	if err := enc.Encode(&s); err != nil {
+		doLog("saveStats: %v", err)
+		f.Close()
+		return
+	}
+	f.Close()
+	if err := os.Rename(tmp, statsFilename); err != nil {
+		doLog("saveStats rename: %v", err)
+	}
+}

--- a/struct.go
+++ b/struct.go
@@ -21,11 +21,14 @@ type tunnelCon struct {
 }
 
 type ephemeralData struct {
-	id       int
-	source   string
-	destPort int
-	lastUsed time.Time
-	listener *net.UDPConn
+	id        int
+	source    string
+	destPort  int
+	lastUsed  time.Time
+	listener  *net.UDPConn
+	startTime time.Time
+	bytesIn   int64
+	bytesOut  int64
 }
 
 type ServerEntry struct {
@@ -35,5 +38,25 @@ type ServerEntry struct {
 }
 
 type PageData struct {
-	Servers []ServerEntry
+	Servers       []ServerEntry
+	CurrentUsers  int
+	PeakUsers     int
+	TotalSessions int
+	Uptime        string
+	Version       string
+	Protocol      int
+	BatchInterval int
+	Compression   int
+	Sessions      []SessionInfo
+	BytesInTotal  int64
+	BytesOutTotal int64
+}
+
+type SessionInfo struct {
+	ID       int
+	Source   string
+	DestPort int
+	Duration string
+	BytesIn  int64
+	BytesOut int64
 }

--- a/struct.go
+++ b/struct.go
@@ -63,3 +63,11 @@ type SessionInfo struct {
 	BytesInStr  string
 	BytesOutStr string
 }
+
+type SavedStats struct {
+	StartTime     time.Time
+	SessionsTotal int
+	PeakUsers     int
+	BytesInTotal  int64
+	BytesOutTotal int64
+}

--- a/struct.go
+++ b/struct.go
@@ -43,8 +43,6 @@ type PageData struct {
 	PeakUsers        int
 	TotalSessions    int
 	Uptime           string
-	Version          string
-	Protocol         int
 	BatchInterval    int
 	Compression      int
 	Sessions         []SessionInfo

--- a/struct.go
+++ b/struct.go
@@ -38,25 +38,28 @@ type ServerEntry struct {
 }
 
 type PageData struct {
-	Servers       []ServerEntry
-	CurrentUsers  int
-	PeakUsers     int
-	TotalSessions int
-	Uptime        string
-	Version       string
-	Protocol      int
-	BatchInterval int
-	Compression   int
-	Sessions      []SessionInfo
-	BytesInTotal  int64
-	BytesOutTotal int64
+	Servers          []ServerEntry
+	CurrentUsers     int
+	PeakUsers        int
+	TotalSessions    int
+	Uptime           string
+	Version          string
+	Protocol         int
+	BatchInterval    int
+	Compression      int
+	Sessions         []SessionInfo
+	BytesInTotal     int64
+	BytesOutTotal    int64
+	BytesInTotalStr  string
+	BytesOutTotalStr string
 }
 
 type SessionInfo struct {
-	ID       int
-	Source   string
-	DestPort int
-	Duration string
-	BytesIn  int64
-	BytesOut int64
+	ID          int
+	DestPort    int
+	Duration    string
+	BytesIn     int64
+	BytesOut    int64
+	BytesInStr  string
+	BytesOutStr string
 }

--- a/templates/private.tmpl
+++ b/templates/private.tmpl
@@ -321,16 +321,17 @@
         <h2>EU Relay Portal</h2>
       </div>
     </a>
-    <div class="stats">
-      <div><span class="material-icons">people</span>Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}</div>
-      <div><span class="material-icons">timer</span>Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}</div>
-      <div><span class="material-icons">build</span>Version: {{.Version}} | Protocol: {{.Protocol}}</div>
-      <div><span class="material-icons">tune</span>Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}</div>
-      {{range .Sessions}}
-      <div>Session {{.ID}} → {{.DestPort}} | {{.Duration}} | in {{.BytesInStr}} / out {{.BytesOutStr}}</div>
-      {{end}}
-      <div>Total In: {{.BytesInTotalStr}} / Out: {{.BytesOutTotalStr}}</div>
-    </div>
+      <div id="stats" class="stats">
+        <div id="stats-users"><span class="material-icons">people</span>Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}</div>
+        <div id="stats-sessions"><span class="material-icons">timer</span>Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}</div>
+        <div id="stats-settings"><span class="material-icons">tune</span>Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}</div>
+        <div id="stats-sessionList">
+        {{range .Sessions}}
+          <div><span class="material-icons">swap_horiz</span>Session {{.ID}} → {{.DestPort}} | {{.Duration}} | in {{.BytesInStr}} / out {{.BytesOutStr}}</div>
+        {{end}}
+        </div>
+        <div id="stats-total"><span class="material-icons">data_usage</span>Total In: {{.BytesInTotalStr}} / Out: {{.BytesOutTotalStr}}</div>
+      </div>
   </header>
 
   <!-- Content Layout -->
@@ -404,6 +405,26 @@
       </ul>
     </div>
   </div>
+
+  <script>
+    function fetchStats() {
+      fetch('serverStats.json')
+        .then(r => r.json())
+        .then(d => {
+          document.getElementById('stats-users').innerHTML = '<span class="material-icons">people</span>Active: ' + d.CurrentUsers + ' / Peak: ' + d.PeakUsers;
+          document.getElementById('stats-sessions').innerHTML = '<span class="material-icons">timer</span>Sessions: ' + d.TotalSessions + ' | Uptime: ' + d.Uptime;
+          document.getElementById('stats-settings').innerHTML = '<span class="material-icons">tune</span>Batch µs: ' + d.BatchInterval + ' | Compression: ' + d.Compression;
+          let sess = '';
+          d.Sessions.forEach(s => {
+            sess += '<div><span class="material-icons">swap_horiz</span>Session ' + s.ID + ' → ' + s.DestPort + ' | ' + s.Duration + ' | in ' + s.BytesInStr + ' / out ' + s.BytesOutStr + '</div>';
+          });
+          document.getElementById('stats-sessionList').innerHTML = sess;
+          document.getElementById('stats-total').innerHTML = '<span class="material-icons">data_usage</span>Total In: ' + d.BytesInTotalStr + ' / Out: ' + d.BytesOutTotalStr;
+        });
+    }
+    setInterval(fetchStats, 5000);
+    fetchStats();
+  </script>
 
 </body>
 

--- a/templates/private.tmpl
+++ b/templates/private.tmpl
@@ -407,23 +407,19 @@
   </div>
 
   <script>
-    function fetchStats() {
-      fetch('serverStats.json')
-        .then(r => r.json())
-        .then(d => {
-          document.getElementById('stats-users').innerHTML = '<span class="material-icons">people</span>Active: ' + d.CurrentUsers + ' / Peak: ' + d.PeakUsers;
-          document.getElementById('stats-sessions').innerHTML = '<span class="material-icons">timer</span>Sessions: ' + d.TotalSessions + ' | Uptime: ' + d.Uptime;
-          document.getElementById('stats-settings').innerHTML = '<span class="material-icons">tune</span>Batch µs: ' + d.BatchInterval + ' | Compression: ' + d.Compression;
-          let sess = '';
-          d.Sessions.forEach(s => {
-            sess += '<div><span class="material-icons">swap_horiz</span>Session ' + s.ID + ' → ' + s.DestPort + ' | ' + s.Duration + ' | in ' + s.BytesInStr + ' / out ' + s.BytesOutStr + '</div>';
-          });
-          document.getElementById('stats-sessionList').innerHTML = sess;
-          document.getElementById('stats-total').innerHTML = '<span class="material-icons">data_usage</span>Total In: ' + d.BytesInTotalStr + ' / Out: ' + d.BytesOutTotalStr;
+    function updateStats() {
+      fetch(window.location.href, {cache: 'no-store'})
+        .then(r => r.text())
+        .then(html => {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const newStats = doc.getElementById('stats');
+          if (newStats) {
+            document.getElementById('stats').innerHTML = newStats.innerHTML;
+          }
         });
     }
-    setInterval(fetchStats, 5000);
-    fetchStats();
+    setInterval(updateStats, 5000);
+    updateStats();
   </script>
 
 </body>

--- a/templates/private.tmpl
+++ b/templates/private.tmpl
@@ -6,6 +6,7 @@
   <title>EU Relay Servers – M45-Science</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link href="icon.png" rel="shortcut icon" type="image/x-icon" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
   <style>
     /* -----------------------------------
@@ -63,19 +64,33 @@
     ------------ */
     header {
       background-color: var(--header-bg);
-      text-align: center;
       padding: 20px 10px;
       box-shadow: 0 4px 10px rgba(0, 0, 0, 0.6);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
 
-    header a {
-      color: inherit;
+    .header-left {
+      display: flex;
+      align-items: center;
       text-decoration: none;
+      color: inherit;
     }
 
-    header img {
+    .header-left img {
       width: 120px;
       height: auto;
+      margin-right: 10px;
+    }
+
+    header h1 {
+      font-size: 2.2rem;
+      margin: 10px 0 5px;
+      /* Gradient text effect */
+      background: linear-gradient(to right, var(--accent-color-1), var(--accent-color-2));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
     }
 
     header h1 {
@@ -92,6 +107,21 @@
       font-weight: normal;
       font-style: italic;
       margin: 0;
+    }
+
+    .stats {
+      text-align: right;
+      font-size: 0.9rem;
+    }
+
+    .stats div {
+      margin: 2px 0;
+    }
+
+    .material-icons {
+      vertical-align: middle;
+      font-size: 1rem;
+      margin-right: 4px;
     }
 
     /* ---------------
@@ -284,11 +314,23 @@
 <body>
   <!-- Header -->
   <header>
-    <a href="https://m45sci.xyz/">
+    <a class="header-left" href="https://m45sci.xyz/">
       <img src="https://m45sci.xyz/img/m45.png" alt="M45-Science Logo" />
-      <h1>M45-Science</h1>
-      <h2>EU Relay Portal</h2>
+      <div>
+        <h1>M45-Science</h1>
+        <h2>EU Relay Portal</h2>
+      </div>
     </a>
+    <div class="stats">
+      <div><span class="material-icons">people</span>Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}</div>
+      <div><span class="material-icons">timer</span>Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}</div>
+      <div><span class="material-icons">build</span>Version: {{.Version}} | Protocol: {{.Protocol}}</div>
+      <div><span class="material-icons">tune</span>Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}</div>
+      {{range .Sessions}}
+      <div>Session {{.ID}} → {{.DestPort}} | {{.Duration}} | in {{.BytesInStr}} / out {{.BytesOutStr}}</div>
+      {{end}}
+      <div>Total In: {{.BytesInTotalStr}} / Out: {{.BytesOutTotalStr}}</div>
+    </div>
   </header>
 
   <!-- Content Layout -->
@@ -362,16 +404,7 @@
       </ul>
     </div>
   </div>
-  <div style="text-align:center;font-size:0.9rem;margin-top:1rem;">
-    Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}<br>
-    Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}<br>
-    Version: {{.Version}} | Protocol: {{.Protocol}}<br>
-    Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}<br>
-    {{range .Sessions}}
-    Session {{.ID}} {{.Source}} → {{.DestPort}} | {{.Duration}} | in {{.BytesIn}}B / out {{.BytesOut}}B<br>
-    {{end}}
-    Total In: {{.BytesInTotal}}B / Out: {{.BytesOutTotal}}B
-  </div>
+
 </body>
 
 </html>

--- a/templates/private.tmpl
+++ b/templates/private.tmpl
@@ -362,6 +362,16 @@
       </ul>
     </div>
   </div>
+  <div style="text-align:center;font-size:0.9rem;margin-top:1rem;">
+    Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}<br>
+    Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}<br>
+    Version: {{.Version}} | Protocol: {{.Protocol}}<br>
+    Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}<br>
+    {{range .Sessions}}
+    Session {{.ID}} {{.Source}} → {{.DestPort}} | {{.Duration}} | in {{.BytesIn}}B / out {{.BytesOut}}B<br>
+    {{end}}
+    Total In: {{.BytesInTotal}}B / Out: {{.BytesOutTotal}}B
+  </div>
 </body>
 
 </html>

--- a/templates/public.tmpl
+++ b/templates/public.tmpl
@@ -156,15 +156,16 @@
         <h2>Bridge Connect Links:</h2>
       </div>
     </a>
-    <div class="stats">
-      <div><span class="material-icons">people</span>Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}</div>
-      <div><span class="material-icons">timer</span>Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}</div>
-      <div><span class="material-icons">build</span>Version: {{.Version}} | Protocol: {{.Protocol}}</div>
-      <div><span class="material-icons">tune</span>Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}</div>
+    <div id="stats" class="stats">
+      <div id="stats-users"><span class="material-icons">people</span>Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}</div>
+      <div id="stats-sessions"><span class="material-icons">timer</span>Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}</div>
+      <div id="stats-settings"><span class="material-icons">tune</span>Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}</div>
+      <div id="stats-sessionList">
       {{range .Sessions}}
-      <div>Session {{.ID}} → {{.DestPort}} | {{.Duration}} | in {{.BytesInStr}} / out {{.BytesOutStr}}</div>
+        <div><span class="material-icons">swap_horiz</span>Session {{.ID}} → {{.DestPort}} | {{.Duration}} | in {{.BytesInStr}} / out {{.BytesOutStr}}</div>
       {{end}}
-      <div>Total In: {{.BytesInTotalStr}} / Out: {{.BytesOutTotalStr}}</div>
+      </div>
+      <div id="stats-total"><span class="material-icons">data_usage</span>Total In: {{.BytesInTotalStr}} / Out: {{.BytesOutTotalStr}}</div>
     </div>
   </header>
 
@@ -181,5 +182,25 @@
   <footer>
     2025 M45-Science
   </footer>
+
+  <script>
+    function fetchStats() {
+      fetch('serverStats.json')
+        .then(r => r.json())
+        .then(d => {
+          document.getElementById('stats-users').innerHTML = '<span class="material-icons">people</span>Active: ' + d.CurrentUsers + ' / Peak: ' + d.PeakUsers;
+          document.getElementById('stats-sessions').innerHTML = '<span class="material-icons">timer</span>Sessions: ' + d.TotalSessions + ' | Uptime: ' + d.Uptime;
+          document.getElementById('stats-settings').innerHTML = '<span class="material-icons">tune</span>Batch µs: ' + d.BatchInterval + ' | Compression: ' + d.Compression;
+          let sess = '';
+          d.Sessions.forEach(s => {
+            sess += '<div><span class="material-icons">swap_horiz</span>Session ' + s.ID + ' → ' + s.DestPort + ' | ' + s.Duration + ' | in ' + s.BytesInStr + ' / out ' + s.BytesOutStr + '</div>';
+          });
+          document.getElementById('stats-sessionList').innerHTML = sess;
+          document.getElementById('stats-total').innerHTML = '<span class="material-icons">data_usage</span>Total In: ' + d.BytesInTotalStr + ' / Out: ' + d.BytesOutTotalStr;
+        });
+    }
+    setInterval(fetchStats, 5000);
+    fetchStats();
+  </script>
 </body>
 </html>

--- a/templates/public.tmpl
+++ b/templates/public.tmpl
@@ -7,6 +7,7 @@
   <!-- Example of optional external stylesheet or favicon references -->
   <link href="m45.css" rel="stylesheet" type="text/css">
   <link href="icon.png" rel="shortcut icon" type="image/x-icon">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   
   <style>
     :root {
@@ -37,17 +38,38 @@
       padding: 0;
     }
 
-    /* Header */
-    header {
-      background-color: var(--header-bg);
-      padding: 2rem 1rem 1rem;
-      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.6);
-    }
-    header .logo {
-      max-width: 120px;
-      height: auto;
-      margin-bottom: 1rem;
-    }
+  /* Header */
+  header {
+    background-color: var(--header-bg);
+    padding: 1.5rem 1rem;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  header .logo {
+    max-width: 120px;
+    height: auto;
+    margin-right: 10px;
+  }
+  .header-left {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+  }
+  .stats {
+    text-align: right;
+    font-size: 0.9rem;
+  }
+  .stats div {
+    margin: 2px 0;
+  }
+  .material-icons {
+    vertical-align: middle;
+    font-size: 1rem;
+    margin-right: 4px;
+  }
     header h1 {
       font-size: 2.2em;
       color: #ffffff;
@@ -127,10 +149,23 @@
 </head>
 <body>
   <header>
-    <!-- Logo -->
-    <img class="logo" src="https://m45sci.xyz/img/m45.png" alt="M45-Science Logo />
-    <h1>M45-Science</h1>
-    <h2>Bridge Connect Links:</h2>
+    <a class="header-left" href="https://m45sci.xyz/">
+      <img class="logo" src="https://m45sci.xyz/img/m45.png" alt="M45-Science Logo" />
+      <div>
+        <h1>M45-Science</h1>
+        <h2>Bridge Connect Links:</h2>
+      </div>
+    </a>
+    <div class="stats">
+      <div><span class="material-icons">people</span>Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}</div>
+      <div><span class="material-icons">timer</span>Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}</div>
+      <div><span class="material-icons">build</span>Version: {{.Version}} | Protocol: {{.Protocol}}</div>
+      <div><span class="material-icons">tune</span>Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}</div>
+      {{range .Sessions}}
+      <div>Session {{.ID}} → {{.DestPort}} | {{.Duration}} | in {{.BytesInStr}} / out {{.BytesOutStr}}</div>
+      {{end}}
+      <div>Total In: {{.BytesInTotalStr}} / Out: {{.BytesOutTotalStr}}</div>
+    </div>
   </header>
 
   <div class="server-list">
@@ -144,15 +179,7 @@
   </div>
 
   <footer>
-    2025 M45-Science<br>
-    Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}<br>
-    Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}<br>
-    Version: {{.Version}} | Protocol: {{.Protocol}}<br>
-    Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}<br>
-    {{range .Sessions}}
-    Session {{.ID}} {{.Source}} → {{.DestPort}} | {{.Duration}} | in {{.BytesIn}}B / out {{.BytesOut}}B<br>
-    {{end}}
-    Total In: {{.BytesInTotal}}B / Out: {{.BytesOutTotal}}B
+    2025 M45-Science
   </footer>
 </body>
 </html>

--- a/templates/public.tmpl
+++ b/templates/public.tmpl
@@ -184,23 +184,19 @@
   </footer>
 
   <script>
-    function fetchStats() {
-      fetch('serverStats.json')
-        .then(r => r.json())
-        .then(d => {
-          document.getElementById('stats-users').innerHTML = '<span class="material-icons">people</span>Active: ' + d.CurrentUsers + ' / Peak: ' + d.PeakUsers;
-          document.getElementById('stats-sessions').innerHTML = '<span class="material-icons">timer</span>Sessions: ' + d.TotalSessions + ' | Uptime: ' + d.Uptime;
-          document.getElementById('stats-settings').innerHTML = '<span class="material-icons">tune</span>Batch µs: ' + d.BatchInterval + ' | Compression: ' + d.Compression;
-          let sess = '';
-          d.Sessions.forEach(s => {
-            sess += '<div><span class="material-icons">swap_horiz</span>Session ' + s.ID + ' → ' + s.DestPort + ' | ' + s.Duration + ' | in ' + s.BytesInStr + ' / out ' + s.BytesOutStr + '</div>';
-          });
-          document.getElementById('stats-sessionList').innerHTML = sess;
-          document.getElementById('stats-total').innerHTML = '<span class="material-icons">data_usage</span>Total In: ' + d.BytesInTotalStr + ' / Out: ' + d.BytesOutTotalStr;
+    function updateStats() {
+      fetch(window.location.href, {cache: 'no-store'})
+        .then(r => r.text())
+        .then(html => {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const newStats = doc.getElementById('stats');
+          if (newStats) {
+            document.getElementById('stats').innerHTML = newStats.innerHTML;
+          }
         });
     }
-    setInterval(fetchStats, 5000);
-    fetchStats();
+    setInterval(updateStats, 5000);
+    updateStats();
   </script>
 </body>
 </html>

--- a/templates/public.tmpl
+++ b/templates/public.tmpl
@@ -144,7 +144,15 @@
   </div>
 
   <footer>
-    2025 M45-Science
+    2025 M45-Science<br>
+    Active: {{.CurrentUsers}} / Peak: {{.PeakUsers}}<br>
+    Sessions: {{.TotalSessions}} | Uptime: {{.Uptime}}<br>
+    Version: {{.Version}} | Protocol: {{.Protocol}}<br>
+    Batch µs: {{.BatchInterval}} | Compression: {{.Compression}}<br>
+    {{range .Sessions}}
+    Session {{.ID}} {{.Source}} → {{.DestPort}} | {{.Duration}} | in {{.BytesIn}}B / out {{.BytesOut}}B<br>
+    {{end}}
+    Total In: {{.BytesInTotal}}B / Out: {{.BytesOutTotal}}B
   </footer>
 </body>
 </html>

--- a/tunnel.go
+++ b/tunnel.go
@@ -102,6 +102,10 @@ func (tun *tunnelCon) readPacket() error {
 		if w != int(payloadLen) {
 			return fmt.Errorf("only wrote %vb of %vb to %v", w, payloadLen, dest.destPort)
 		}
+		ephemeralLock.Lock()
+		dest.bytesIn += int64(w)
+		bytesInTotal += int64(w)
+		ephemeralLock.Unlock()
 		if verboseDebug {
 			doLog("wrote %vb to %v", w, dest.destPort)
 		}


### PR DESCRIPTION
## Summary
- track session stats and uptime
- show active, peak, and total sessions on generated HTML
- track per-session bandwidth and display version/protocol info

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854b3e69b00832a9ed2a9e8c467a6f4